### PR TITLE
Add wheel theme demo

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,6 +48,7 @@
     <link href="dist/themes/classic.min.css" rel="stylesheet"/>
     <link href="dist/themes/monolith.min.css" rel="stylesheet"/>
     <link href="dist/themes/nano.min.css" rel="stylesheet"/>
+    <link href="dist/themes/wheel.min.css" rel="stylesheet"/>
     <link href="www/index.css" rel="stylesheet"/>
 </head>
 

--- a/www/index.js
+++ b/www/index.js
@@ -96,6 +96,46 @@ const themes = [
                 }
             }
         }
+    ],
+    [
+        'wheel',
+        {
+            swatches: [
+                'rgba(244, 67, 54, 1)',
+                'rgba(233, 30, 99, 0.95)',
+                'rgba(156, 39, 176, 0.9)',
+                'rgba(103, 58, 183, 0.85)',
+                'rgba(63, 81, 181, 0.8)',
+                'rgba(33, 150, 243, 0.75)',
+                'rgba(3, 169, 244, 0.7)',
+                'rgba(0, 188, 212, 0.7)',
+                'rgba(0, 150, 136, 0.75)',
+                'rgba(76, 175, 80, 0.8)',
+                'rgba(139, 195, 74, 0.85)',
+                'rgba(205, 220, 57, 0.9)',
+                'rgba(255, 235, 59, 0.95)',
+                'rgba(255, 193, 7, 1)'
+            ],
+
+            wheel: {
+                rings: 5
+            },
+
+            components: {
+                preview: true,
+                opacity: true,
+                hue: true,
+
+                interaction: {
+                    hex: true,
+                    rgba: true,
+                    hsva: true,
+                    input: true,
+                    clear: true,
+                    save: true
+                }
+            }
+        }
     ]
 ];
 


### PR DESCRIPTION
## Summary
- add wheel theme stylesheet to demo page
- extend demo script with wheel theme configuration

## Testing
- `npm run test:ci` *(fails: Cannot find module 'webpack-remove-empty-scripts')*

------
https://chatgpt.com/codex/tasks/task_e_685eaa1152688325bcfb5de8146acbbe